### PR TITLE
Change base path in Vite config to '/app/'

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
     plugins: [react()],
-    base: '/',
+    base: '/app/',
     css: {
       devSourcemap: false
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the application’s deployment path to ensure assets and navigation load correctly under the `/app/` URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->